### PR TITLE
SRE-2 increase nginx proxy timeouts to reduce incidence of 504 errors

### DIFF
--- a/dewey/conf/etc/nginx/sites-available/dewey.conf
+++ b/dewey/conf/etc/nginx/sites-available/dewey.conf
@@ -36,6 +36,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_redirect off;
+        proxy_connect_timeout       300;
+        proxy_send_timeout          300;
+        proxy_read_timeout          300;
+        send_timeout                300;
         if (!-f $request_filename) {
             proxy_pass http://dewey;
             break;


### PR DESCRIPTION
http/504 indicates a proxy timeout.

Deleting multiple hosts at once requires django to find all of the salt events and other objects related to each host, which can be quite a lot of database queries/results.

I'm going to increase the nginx proxy timeout to 5 minutes, which should, in most cases, give it adequate headroom to find all the metadata. If this continues to be a problem, try selecting fewer hosts to delete in one go.
